### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ios-sdk-new-version.yaml
+++ b/.github/workflows/ios-sdk-new-version.yaml
@@ -1,5 +1,8 @@
 name: MeetingLawyersSDK New Version
 
+permissions:
+  contents: write
+
 on:
   repository_dispatch:
     types: [new_version_created]


### PR DESCRIPTION
Potential fix for [https://github.com/MeetingLawyers/ios-sdk-spm-meetinglawyers/security/code-scanning/1](https://github.com/MeetingLawyers/ios-sdk-spm-meetinglawyers/security/code-scanning/1)

Add an explicit `permissions` block in `.github/workflows/ios-sdk-new-version.yaml` at the workflow root (top-level), so it applies to the job unless overridden.  
Given current behavior (checkout + commit/push + tag push), the minimal non-breaking permission is:

- `contents: write`

This documents intent and prevents dependence on broader repository defaults while preserving existing functionality. No imports, methods, or external definitions are needed—only YAML key insertion near the top-level keys (`name`, `on`, `jobs`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
